### PR TITLE
fix arm repo

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -22,6 +22,7 @@ on:
 env:
   REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
   OTEL_COLLECTOR_CONTAINER_NAME: apo-otel-collector
+  REGISTRY_USERNAME_ARM: originx
 
 jobs:
   build-images:
@@ -63,7 +64,7 @@ jobs:
         run: |
           echo "IMAGE_TAG_NAME=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
           echo "OTEL_COLLECTOR_IMAGE_FULL_TAG_AMD64=${{ env.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.OTEL_COLLECTOR_CONTAINER_NAME }}:${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          echo "OTEL_COLLECTOR_IMAGE_FULL_TAG_ARM64=${{ env.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.OTEL_COLLECTOR_CONTAINER_NAME }}:${{ github.event.inputs.tag }}-arm64" >> $GITHUB_ENV
+          echo "OTEL_COLLECTOR_IMAGE_FULL_TAG_ARM64=${{ env.REGISTRY_HOST }}/${{ env.REGISTRY_USERNAME_ARM }}/${{ env.OTEL_COLLECTOR_CONTAINER_NAME }}:${{ github.event.inputs.tag }}" >> $GITHUB_ENV
 
       - name: Build and push AMD64 image
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary by Sourcery

Fix ARM64 image release in CI by adding a dedicated ARM registry username and updating the ARM image tag generation

Bug Fixes:
- Correct the registry username used for ARM64 images in the release workflow by introducing a separate ARM-specific variable

Enhancements:
- Remove the hardcoded '-arm64' suffix from the ARM image tag

CI:
- Add REGISTRY_USERNAME_ARM environment variable to release-image.yml
- Update OTEL_COLLECTOR_IMAGE_FULL_TAG_ARM64 to use the ARM registry username and the standard tag